### PR TITLE
Fix non working slim settings.

### DIFF
--- a/res/xml/dashboard_categories.xml
+++ b/res/xml/dashboard_categories.xml
@@ -88,7 +88,7 @@
         <dashboard-tile
                 android:id="@+id/status_bar_settings"
                 android:title="@string/status_bar_title"
-                android:fragment="com.android.settings.cyanogenmod.StatusBarSettings"
+                android:fragment="com.android.settings.slim.StatusBar"
                 android:icon="@drawable/ic_settings_home"
                 />
 

--- a/res/xml/status_bar_settings.xml
+++ b/res/xml/status_bar_settings.xml
@@ -42,21 +42,21 @@
             android:summary="@string/status_bar_toggle_brightness_summary"
             android:defaultValue="false" />
 
-        <ListPreference
+        <com.android.settings.cyanogenmod.SystemSettingListPreference
             android:key="quick_pulldown"
             android:title="@string/title_quick_pulldown"
             android:entries="@array/quick_pulldown_entries"
             android:entryValues="@array/quick_pulldown_values"
             android:persistent="false" />
 
-        <ListPreference
+        <com.android.settings.cyanogenmod.SystemSettingListPreference
             android:key="smart_pulldown"
             android:title="@string/smart_pulldown_title"
             android:entries="@array/smart_pulldown_entries"
             android:entryValues="@array/smart_pulldown_values"
             android:persistent="false" />
 
-        <SwitchPreference
+        <com.android.settings.cyanogenmod.SystemSettingSwitchPreference
             android:key="block_on_secure_keyguard"
             android:title="@string/block_on_secure_keyguard_title"
             android:summary="@string/block_on_secure_keyguard_summary"
@@ -74,13 +74,13 @@
         android:key="recents_panel"
         android:title="@string/recents_panel_settings" >
 
-        <SwitchPreference
+        <com.android.settings.cyanogenmod.SystemSettingSwitchPreference
             android:key="show_clear_all_recents"
             android:title="@string/show_clear_all_recents_button_title"
             android:summary="@string/show_clear_all_recents_button_summary"
             android:defaultValue="true" />
 
-        <ListPreference
+        <com.android.settings.cyanogenmod.SystemSettingListPreference
             android:key="recents_clear_all_location"
             android:title="@string/recents_clear_all_location_title"
             android:entries="@array/recents_clear_all_location_entries"

--- a/src/com/android/settings/cyanogenmod/SystemSettingListPreference.java
+++ b/src/com/android/settings/cyanogenmod/SystemSettingListPreference.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2014 The CyanogenMod project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.cyanogenmod;
+
+import android.content.Context;
+import android.preference.ListPreference;
+import android.provider.Settings;
+import android.util.AttributeSet;
+
+public class SystemSettingListPreference extends ListPreference {
+    public SystemSettingListPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public SystemSettingListPreference(Context context) {
+        super(context, null);
+    }
+
+    @Override
+    protected boolean persistString(String value) {
+        if (shouldPersist()) {
+            if (value == getPersistedString(null)) {
+                // It's already there, so the same as persisting
+                return true;
+            }
+
+            Settings.System.putString(getContext().getContentResolver(), getKey(), value);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    protected String getPersistedString(String defaultReturnValue) {
+        if (!shouldPersist()) {
+            return defaultReturnValue;
+        }
+
+        return Settings.System.getString(getContext().getContentResolver(), getKey());
+    }
+
+    @Override
+    protected boolean isPersisted() {
+        return Settings.System.getString(getContext().getContentResolver(), getKey()) != null;
+    }
+}


### PR DESCRIPTION
Due to having two statusbar.java files one for CM and one for slim, settings can only reference the one that called it.

Add cm helper for listpref
Switch all cm settings to helpers
Switch to calling status bar from slim. This removes the need to add helpers to slim.
