### PR TITLE
Fix screen timeout preference summary

### DIFF
--- a/res/values/cr_strings.xml
+++ b/res/values/cr_strings.xml
@@ -5,7 +5,7 @@
     <!-- About phone screen, Temasek version -->
     <string name="temasek_version_title">Temasek unofficial version</string>
     <!-- Do NOT translate this -->
-    <string name="temasek_version_default">Build V3.7</string>
+    <string name="temasek_version_default">Build V3.8</string>
 
     <!-- temasek spare parts -->
     <string name="temasek_settings_title">Temasek spare parts</string>

--- a/src/com/android/settings/DisplaySettings.java
+++ b/src/com/android/settings/DisplaySettings.java
@@ -337,7 +337,7 @@ public class DisplaySettings extends SettingsPreferenceFragment implements
                 for (int i = 0; i < values.length; i++) {
                     long timeout = Long.parseLong(values[i].toString());
                     try {
-                        if (currentTimeout > timeout) {
+                        if (currentTimeout >= timeout) {
                            best = i;
                         }
                     } catch (Exception e) {


### PR DESCRIPTION
Without the >=, you get the wrong index.  You get the index one less than what you'd expect.
