### PR TITLE
Remove carrier label if Msim

### DIFF
--- a/src/com/android/settings/cyanogenmod/StatusBarSettings.java
+++ b/src/com/android/settings/cyanogenmod/StatusBarSettings.java
@@ -29,6 +29,7 @@ import android.preference.PreferenceScreen;
 import android.preference.SwitchPreference;
 import android.provider.Settings;
 import android.provider.Settings.SettingNotFoundException;
+import android.telephony.TelephonyManager;
 import android.text.TextUtils;
 import android.view.View;
 import android.widget.Toast;
@@ -73,7 +74,8 @@ public class StatusBarSettings extends SettingsPreferenceFragment implements
         updateClockStyleDescription();
 
         mCarrierLabel = (PreferenceScreen) prefSet.findPreference(KEY_CARRIERLABEL_PREFERENCE);
-        if (Utils.isWifiOnly(getActivity())) {
+        if (Utils.isWifiOnly(getActivity()) || 
+        TelephonyManager.getDefault().isMultiSimEnabled()) {
             prefSet.removePreference(mCarrierLabel);
         }
 


### PR DESCRIPTION
This needs to be removed on Msim devices as the code doesnt cope with multisim and its makes no sense to display two carrier names.
Not tested just yet, putting here for reference
