### PR TITLE
Custom recents toggle (2/2)

### DIFF
--- a/res/values/cr_strings.xml
+++ b/res/values/cr_strings.xml
@@ -1081,6 +1081,10 @@
     <string name="recent_card_bg_color_title">Card background color</string>
     <string name="recent_card_text_color_title">Card text color</string>
 
+    <!-- Custom Recents Toggle -->
+    <string name="custom_recent_title">Enable Slim Recents</string>
+    <string name="custom_recent_summary">Choose between Slim/Stock RecentApps</string>
+
     <!-- ATTENTION: RTL languages need to replace left with right -->
     <string name="recent_panel_lefty_mode_title">Show on the left edge</string>
     <string name="recent_panel_lefty_mode_summary">Show recent apps panel on the left edge</string>

--- a/res/xml/recents_panel_settings.xml
+++ b/res/xml/recents_panel_settings.xml
@@ -61,10 +61,19 @@
 
     </PreferenceCategory>
 
+    <!-- Custom Recents Toggle -->
+    <SwitchPreference
+        android:key="custom_recent_mode"
+        android:title="@string/custom_recent_title"
+        android:summary="@string/custom_recent_summary"
+        android:persistent="false" />
+
+    <!-- Slim Recents -->
     <PreferenceScreen
         android:key="recent_panel"
         android:fragment="com.android.settings.temasek.RecentPanel"
-        android:title="@string/recent_panel_category" />
+        android:title="@string/recent_panel_category"
+        android:dependency="custom_recent_mode" />
 
     <!-- OmniSwitch -->
     <PreferenceScreen

--- a/src/com/android/settings/temasek/RecentsPanelSettings.java
+++ b/src/com/android/settings/temasek/RecentsPanelSettings.java
@@ -29,6 +29,8 @@ import android.provider.Settings;
 import com.android.settings.SettingsPreferenceFragment;
 import com.android.settings.R;
 
+import com.android.settings.util.Helpers;
+
 public class RecentsPanelSettings extends SettingsPreferenceFragment implements
         Preference.OnPreferenceChangeListener {
 
@@ -36,9 +38,11 @@ public class RecentsPanelSettings extends SettingsPreferenceFragment implements
 
     private static final String SHOW_CLEAR_ALL_RECENTS = "show_clear_all_recents";
     private static final String RECENTS_CLEAR_ALL_LOCATION = "recents_clear_all_location";
+    private static final String CUSTOM_RECENT_MODE = "custom_recent_mode";
     
     private SwitchPreference mRecentsClearAll;
     private ListPreference mRecentsClearAllLocation;
+    private SwitchPreference mRecentsCustom;
 
     @Override
     public void onCreate(Bundle icicle) {
@@ -59,6 +63,12 @@ public class RecentsPanelSettings extends SettingsPreferenceFragment implements
         mRecentsClearAllLocation.setValue(String.valueOf(location));
         mRecentsClearAllLocation.setOnPreferenceChangeListener(this);
         updateRecentsLocation(location);
+
+	boolean enableRecentsCustom = Settings.System.getBoolean(getContentResolver(),
+                                      Settings.System.CUSTOM_RECENT, false);
+        mRecentsCustom = (SwitchPreference) findPreference(CUSTOM_RECENT_MODE);
+        mRecentsCustom.setChecked(enableRecentsCustom);
+        mRecentsCustom.setOnPreferenceChangeListener(this);
     }
 
     @Override
@@ -77,6 +87,12 @@ public class RecentsPanelSettings extends SettingsPreferenceFragment implements
             Settings.System.putIntForUser(getActivity().getContentResolver(),
                     Settings.System.RECENTS_CLEAR_ALL_LOCATION, location, UserHandle.USER_CURRENT);
             updateRecentsLocation(location);
+            return true;
+	} else if (preference == mRecentsCustom) {
+            Settings.System.putBoolean(getActivity().getContentResolver(),
+                    Settings.System.CUSTOM_RECENT,
+                    ((Boolean) objValue) ? true : false);
+            Helpers.restartSystemUI();
             return true;
         }
         return false;


### PR DESCRIPTION
This toggle allows you to choose between aosp and slim recents.
Omni recents will override both when enabled.

Signed-off-by: BlackDragon blackdragon.fusionteam@gmail.com
