### PR TITLE
[Fix] error 'IndexOutOfBoundsException'

### DIFF
--- a/res/values/cr_arrays.xml
+++ b/res/values/cr_arrays.xml
@@ -840,6 +840,7 @@
         <item>21</item>
         <item>22</item>
         <item>23</item>
+        <item>24</item>
     </string-array>
 
     <!-- Pie control -->


### PR DESCRIPTION
[Fix] Settings.apk forced close , when choosing font style 'NotoSerif Bold Italic' on statusbar clock font style
