### PR TITLE
Dynamically define currently installed vendor.img version

### DIFF
--- a/res/values/cr_strings.xml
+++ b/res/values/cr_strings.xml
@@ -1267,4 +1267,7 @@
     <string name="toggle_package_install_overlay_check_title">Disable permission overlay check</string>
     <string name="toggle_package_install_overlay_check_summary">WARNING\u003A this disables a security check to prevent possible tapjacking! Use only if you understand the consequences.</string>
 
+    <!-- Vendor version -->
+    <string name="vendor_version">Vendor version</string>
+    <string name="vendor_version_default">Unknown</string>
 </resources>

--- a/res/xml/device_info_settings.xml
+++ b/res/xml/device_info_settings.xml
@@ -160,6 +160,12 @@
                 android:title="@string/build_number"
                 android:summary="@string/device_info_default"/>
 
+	<!-- Vendor Version -->
+        <Preference android:key="vendor_version"
+                style="?android:preferenceInformationStyle"
+                android:title="@string/vendor_version"
+                android:summary="@string/vendor_version_default" />        
+
         <!-- SELinux status information -->
         <Preference android:key="selinux_status"
                 style="?android:preferenceInformationStyle"

--- a/src/com/android/settings/DeviceInfoSettings.java
+++ b/src/com/android/settings/DeviceInfoSettings.java
@@ -91,6 +91,7 @@ public class DeviceInfoSettings extends SettingsPreferenceFragment implements In
     private static final String KEY_MOD_API_LEVEL = "mod_api_level";
     private static final String KEY_DEVICE_CPU = "device_cpu";
     private static final String KEY_DEVICE_MEMORY = "device_memory";
+    private static final String KEY_VENDOR_VERSION = "vendor_version";
 
     static final int TAPS_TO_BE_A_DEVELOPER = 7;
 
@@ -130,6 +131,14 @@ public class DeviceInfoSettings extends SettingsPreferenceFragment implements In
         } else {
             getPreferenceScreen().removePreference(findPreference(KEY_SECURITY_PATCH));
 
+        }
+        String vendorfingerprint = SystemProperties.get("ro.vendor.build.fingerprint");
+        if (vendorfingerprint != null && !TextUtils.isEmpty(vendorfingerprint)) {
+            String[] splitfingerprint = vendorfingerprint.split("/");
+            String vendorid = splitfingerprint[3];
+            setStringSummary(KEY_VENDOR_VERSION, vendorid);
+        } else {
+            getPreferenceScreen().removePreference(findPreference(KEY_VENDOR_VERSION));
         }
         setValueSummary(KEY_BASEBAND_VERSION, "gsm.version.baseband");
         setValueSummary(KEY_EQUIPMENT_ID, PROPERTY_EQUIPMENT_ID);


### PR DESCRIPTION
*parse the vendor fingerprint for the vendor build id
*automatically remove on devices without a vendor image

Thanks to @dwitherell for the help with the parsing logic :)

Signed-off-by: Joshndroid fmxjoshiewah@gmail.com
